### PR TITLE
Add proposal fields

### DIFF
--- a/app/views/proposal/new.html.haml
+++ b/app/views/proposal/new.html.haml
@@ -57,6 +57,8 @@
                   250
                 words.
 
+              = f.input :diversity, as: :boolean, label: 'I identify as a member of a group that is historically under-represented in technology'
+
               = f.input :require_registration, label: 'Require participants to register to your event'
 
               %p.text-right

--- a/app/views/proposal/new.html.haml
+++ b/app/views/proposal/new.html.haml
@@ -59,6 +59,8 @@
 
               = f.input :diversity, as: :boolean, label: 'I identify as a member of a group that is historically under-represented in technology'
 
+              = f.input :first_time, as: :boolean, label: 'This will be my first time speaking at a conference'
+
               = f.input :require_registration, label: 'Require participants to register to your event'
 
               %p.text-right

--- a/db/migrate/20170613224853_add_diversity_to_events.rb
+++ b/db/migrate/20170613224853_add_diversity_to_events.rb
@@ -1,0 +1,5 @@
+class AddDiversityToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :diversity, :boolean, default: false
+  end
+end

--- a/db/migrate/20170614025428_add_first_time_to_events.rb
+++ b/db/migrate/20170614025428_add_first_time_to_events.rb
@@ -1,0 +1,5 @@
+class AddFirstTimeToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :first_time, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170613224853) do
+ActiveRecord::Schema.define(version: 20170614025428) do
 
   create_table "ahoy_events", force: :cascade do |t|
     t.uuid     "visit_id",   limit: 16
@@ -233,6 +233,7 @@ ActiveRecord::Schema.define(version: 20170613224853) do
     t.integer  "program_id"
     t.integer  "max_attendees"
     t.boolean  "diversity",                    default: false
+    t.boolean  "first_time",                   default: false
   end
 
   create_table "events_registrations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160815140302) do
+ActiveRecord::Schema.define(version: 20170613224853) do
 
   create_table "ahoy_events", force: :cascade do |t|
     t.uuid     "visit_id",   limit: 16
@@ -232,6 +232,7 @@ ActiveRecord::Schema.define(version: 20160815140302) do
     t.boolean  "is_highlight",                 default: false
     t.integer  "program_id"
     t.integer  "max_attendees"
+    t.boolean  "diversity",                    default: false
   end
 
   create_table "events_registrations", force: :cascade do |t|


### PR DESCRIPTION
We'd like to add these two fields to the proposal field for the 2018 CFP. I _think_ this PR should be sufficient for that. 

We also need to be able to _see_ this data when reviewing talk proposals. I'm not entirely sure where those modifications need to be made. I'm also not sure what level of testing is considered appropriate in this project for this type of change. 

Additionally, @vmbrasseur mentioned also adding an aggregate measure of both of these to the dashboard, so that we can have some ongoing feedback on the how we'd doing on both fronts.

Finally, our current timeframe for opening the CFP is June 19th (i.e., next Monday). **Ideally** we will be able to get these changes completed by then, if at all possible? 