### PR TITLE
Add ability to toggle speaker requirements to CFP setup

### DIFF
--- a/app/assets/stylesheets/osem.css.scss
+++ b/app/assets/stylesheets/osem.css.scss
@@ -90,3 +90,7 @@ p.comment-body {
 .changeset{
   display: none;
 }
+
+dt.tall-definition-label {
+  white-space: pre-line;
+}

--- a/app/controllers/admin/cfps_controller.rb
+++ b/app/controllers/admin/cfps_controller.rb
@@ -54,7 +54,24 @@ module Admin
     private
 
     def cfp_params
-      params.require(:cfp).permit(:start_date, :end_date)
+      # Do a bit of param massaging.
+      # 1. For some reason fields_for @cfp.program in the view produces a slightly
+      # wrong parameter name that can't be used with assign/update_attributes.
+      # Fix this by renaming :program to :program_attributes.
+      # 2. Starting with a CFP model object such as
+      # @cfp = #<Cfp id: 1, ... , program_id: 1>
+      # running .update_attributes on that with {... "program_attributes"=>{"speaker_proposals_req_speaker_event_reg"=>"true"}}
+      # should simply update the program associated with that CFP. Unfortunately,
+      # it also sets @cfp.program_id to nil. Not clear why as update_attributes
+      # is supposed to merge rather than replace, but the workaround is to inject
+      # the @cfp's program_id into the incoming parameters so the link is not lost.
+
+    cfp = params.require(:cfp)
+      cfp[:program_attributes] = cfp.delete(:program) if cfp.has_key? :program
+      cfp[:program_attributes][:id] = @cfp.program.id
+
+      cfp.permit(:start_date, :end_date,
+                 program_attributes: [ :id, :speaker_proposals_req_speaker_event_reg, :speaker_proposals_req_bio, :speaker_proposals_req_subtitle, :speaker_proposals_req_commercial, :speaker_proposals_req_track, :speaker_proposals_req_difficulty_level])
     end
   end
 end

--- a/app/models/cfp.rb
+++ b/app/models/cfp.rb
@@ -3,6 +3,7 @@
 class Cfp < ActiveRecord::Base
   has_paper_trail ignore: [:updated_at], meta: { conference_id: :conference_id }
   belongs_to :program
+  accepts_nested_attributes_for :program
 
   validates :program_id, presence: true
   validates :start_date, :end_date, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -213,16 +213,36 @@ class Event < ActiveRecord::Base
   #
   # Returns +Hash+
   def progress_status
-    {
-      registered: speakers.all? { |speaker| program.conference.user_registered? speaker },
-      commercials: commercials.any?,
-      biographies: speakers.all? { |speaker| !speaker.biography.blank? },
-      subtitle: !subtitle.blank?,
-      track: (!track.blank? unless program.tracks.empty?),
-      difficulty_level: !difficulty_level.blank?,
+    status = {
       title: true,
       abstract: true
-    }.with_indifferent_access
+    }
+
+    if self.program.speaker_proposals_req_speaker_event_reg
+      status.merge!(registered: speakers.all? { |speaker| program.conference.user_registered? speaker })
+    end
+
+    if self.program.speaker_proposals_req_bio
+      status.merge!(biographies: speakers.all? { |speaker| !speaker.biography.blank? })
+    end
+
+    if self.program.speaker_proposals_req_subtitle
+      status.merge!(subtitle: !subtitle.blank?)
+    end
+
+    if self.program.speaker_proposals_req_commercial
+      status.merge!(commercials: commercials.any?)
+    end
+
+    if self.program.speaker_proposals_req_track
+      status.merge!(track: (!track.blank? unless program.tracks.empty?))
+    end
+
+    if self.program.speaker_proposals_req_difficulty_level
+      status.merge!(difficulty_level: !difficulty_level.blank?)
+    end
+
+    status.with_indifferent_access
   end
 
   ##

--- a/app/views/admin/cfps/_form.html.haml
+++ b/app/views/admin/cfps/_form.html.haml
@@ -7,5 +7,12 @@
     = semantic_form_for(@cfp, url: admin_conference_program_cfp_path(@conference.short_title), html: {multipart: true}) do |f|
       = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker', start_date: @conference.start_date, end_date: @conference.end_date, readonly: 'readonly' }
       = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly' }
+      = f.fields_for @cfp.program do |p|
+        = p.input :speaker_proposals_req_speaker_event_reg, as: :radio, label: 'Speakers todo: remind to register for event', input_html: { id: 'speaker_proposals_req_speaker_event_reg'}
+        = p.input :speaker_proposals_req_bio, as: :radio, label: 'Speakers todo: remind to fill out bio', input_html: { id: 'speaker_proposals_req_bio'}
+        = p.input :speaker_proposals_req_subtitle, as: :radio, label: 'Speakers todo: remind to add subtitle', input_html: { id: 'speaker_proposals_req_subtitle'}
+        = p.input :speaker_proposals_req_commercial, as: :radio, label: 'Speakers todo: remind to add a commercial', input_html: { id: 'speaker_proposals_req_commercial'}
+        = p.input :speaker_proposals_req_track, as: :radio, label: 'Speakers todo: remind to add track', input_html: { id: 'speaker_proposals_req_track'}
+        = p.input :speaker_proposals_req_difficulty_level, as: :radio, label: 'Speakers todo: remind to add difficulty level', input_html: { id: 'speaker_proposals_req_difficulty_level'}
       %p.text-right
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/cfps/show.html.haml
+++ b/app/views/admin/cfps/show.html.haml
@@ -49,45 +49,27 @@
 
         %dt.tall-definition-label Speakers todo: remind to register for event
         %dd#speaker_proposals_req_speaker_event_reg
-          - if @program.speaker_proposals_req_speaker_event_reg
-            Yes
-          - else
-            No
+          = @program.speaker_proposals_req_speaker_event_reg ? 'Yes' : 'No'
 
         %dt.tall-definition-label Speakers todo: remind to fill out bio
         %dd#speaker_proposals_req_bio
-          - if @program.speaker_proposals_req_bio
-            Yes
-          - else
-            No
+          - @program.speaker_proposals_req_bio ? 'Yes' : 'No'
 
         %dt.tall-definition-label Speakers todo: remind to add subtitle
         %dd#speaker_proposals_req_subtitle
-          - if @program.speaker_proposals_req_subtitle
-            Yes
-          - else
-            No
+          - @program.speaker_proposals_req_subtitle ? 'Yes' : 'No'
 
         %dt.tall-definition-label Speakers todo: remind to add a commercial
         %dd#speaker_proposals_req_commercial
-          - if @program.speaker_proposals_req_commercial
-            Yes
-          - else
-            No
+          - @program.speaker_proposals_req_commercial ? 'Yes' : 'No'
 
         %dt.tall-definition-label Speakers todo: remind to add track
         %dd#speaker_proposals_req_track
-          - if @program.speaker_proposals_req_track
-            Yes
-          - else
-            No
+          - @program.speaker_proposals_req_track ? 'Yes' : 'No'
 
         %dt.tall-definition-label Speakers todo: remind to add difficulty level
         %dd#speaker_proposals_req_difficulty_level
-          - if @program.speaker_proposals_req_difficulty_level
-            Yes
-          - else
-            No
+          - @program.speaker_proposals_req_difficulty_level ? 'Yes' : 'No'
   .row
     .col-md-12.text-right
       = link_to(edit_admin_conference_program_cfp_path(@conference.short_title), class: 'btn btn-primary') do

--- a/app/views/admin/cfps/show.html.haml
+++ b/app/views/admin/cfps/show.html.haml
@@ -46,6 +46,48 @@
           Rating Levels
         %dd#rating
           = @program.rating
+
+        %dt.tall-definition-label Speakers todo: remind to register for event
+        %dd#speaker_proposals_req_speaker_event_reg
+          - if @program.speaker_proposals_req_speaker_event_reg
+            Yes
+          - else
+            No
+
+        %dt.tall-definition-label Speakers todo: remind to fill out bio
+        %dd#speaker_proposals_req_bio
+          - if @program.speaker_proposals_req_bio
+            Yes
+          - else
+            No
+
+        %dt.tall-definition-label Speakers todo: remind to add subtitle
+        %dd#speaker_proposals_req_subtitle
+          - if @program.speaker_proposals_req_subtitle
+            Yes
+          - else
+            No
+
+        %dt.tall-definition-label Speakers todo: remind to add a commercial
+        %dd#speaker_proposals_req_commercial
+          - if @program.speaker_proposals_req_commercial
+            Yes
+          - else
+            No
+
+        %dt.tall-definition-label Speakers todo: remind to add track
+        %dd#speaker_proposals_req_track
+          - if @program.speaker_proposals_req_track
+            Yes
+          - else
+            No
+
+        %dt.tall-definition-label Speakers todo: remind to add difficulty level
+        %dd#speaker_proposals_req_difficulty_level
+          - if @program.speaker_proposals_req_difficulty_level
+            Yes
+          - else
+            No
   .row
     .col-md-12.text-right
       = link_to(edit_admin_conference_program_cfp_path(@conference.short_title), class: 'btn btn-primary') do

--- a/app/views/proposals/_tooltip.html.haml
+++ b/app/views/proposals/_tooltip.html.haml
@@ -1,29 +1,40 @@
 - progress_status = event.progress_status
 %ul.list-unstyled
-  %li{'class'=>class_for_todo(progress_status['registered'])}
-    %span{'class'=>icon_for_todo(progress_status['registered'])}
-      - if progress_status['registered']
-        Speaker(s) registered to the conference
-      - else
-        = link_to 'Speaker(s) not registered to the conference', new_conference_conference_registration_path(event.program.conference.short_title)
-  %li{'class'=>class_for_todo(progress_status['biographies'])}
-    %span{'class'=>icon_for_todo(progress_status['biographies'])}
-      - if progress_status['biographies']
-        Speakers have filled out their biographies
-      - elsif current_user.biography.blank? && event.speakers.include?(current_user)
-        = link_to 'Fill out your biography', edit_user_path(current_user)
-      - else
-        Speakers' biographies missing
-  %li{'class'=>class_for_todo(progress_status['subtitle'])}
-    %span{'class'=>icon_for_todo(progress_status['subtitle'])}
-      = link_to 'Add a subtitle', edit_conference_program_proposal_path(event.program.conference.short_title, event)
-  %li{'class'=>class_for_todo(progress_status['commercials'])}
-    %span{'class'=>icon_for_todo(progress_status['commercials'])}
-      = link_to 'Add a commercial', edit_conference_program_proposal_path(event.program.conference.short_title, event, anchor: 'commercials-content')
-  - unless progress_status['track'].nil?
-    %li{'class'=>class_for_todo(progress_status['track'])}
-      %span{'class'=>icon_for_todo(progress_status['track'])}
-        = link_to 'Add a track', edit_conference_program_proposal_path(event.program.conference.short_title, event)
-  %li{'class'=>class_for_todo(progress_status['difficulty_level'])}
-    %span{'class'=>icon_for_todo(progress_status['difficulty_level'])}
-      = link_to 'Add a difficulty level', edit_conference_program_proposal_path(event.program.conference.short_title, event)
+  - if @program.speaker_proposals_req_speaker_event_reg
+    %li{'class'=>class_for_todo(progress_status['registered'])}
+      %span{'class'=>icon_for_todo(progress_status['registered'])}
+        - if progress_status['registered']
+          Speaker(s) registered to the conference
+        - else
+          = link_to 'Speaker(s) not registered to the conference', new_conference_conference_registration_path(event.program.conference.short_title)
+
+  - if @program.speaker_proposals_req_bio
+    %li{'class'=>class_for_todo(progress_status['biographies'])}
+      %span{'class'=>icon_for_todo(progress_status['biographies'])}
+        - if progress_status['biographies']
+          Speakers have filled out their biographies
+        - elsif current_user.biography.blank? && event.speakers.include?(current_user)
+          = link_to 'Fill out your biography', edit_user_path(current_user)
+        - else
+          Speakers' biographies missing
+
+  - if @program.speaker_proposals_req_subtitle
+    %li{'class'=>class_for_todo(progress_status['subtitle'])}
+      %span{'class'=>icon_for_todo(progress_status['subtitle'])}
+        = link_to 'Add a subtitle', edit_conference_program_proposal_path(event.program.conference.short_title, event)
+
+  - if @program.speaker_proposals_req_commercial
+    %li{'class'=>class_for_todo(progress_status['commercials'])}
+      %span{'class'=>icon_for_todo(progress_status['commercials'])}
+        = link_to 'Add a commercial', edit_conference_program_proposal_path(event.program.conference.short_title, event, anchor: 'commercials-content')
+
+  - if @program.speaker_proposals_req_track
+    - unless progress_status['track'].nil?
+      %li{'class'=>class_for_todo(progress_status['track'])}
+        %span{'class'=>icon_for_todo(progress_status['track'])}
+          = link_to 'Add a track', edit_conference_program_proposal_path(event.program.conference.short_title, event)
+
+  - if @program.speaker_proposals_req_difficulty_level
+    %li{'class'=>class_for_todo(progress_status['difficulty_level'])}
+      %span{'class'=>icon_for_todo(progress_status['difficulty_level'])}
+        = link_to 'Add a difficulty level', edit_conference_program_proposal_path(event.program.conference.short_title, event)

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -72,13 +72,14 @@
                     %br
                     = link_to registered_text(event), registrations_conference_program_proposal_path(@conference.short_title, event), class: 'btn btn-xs btn-danger'
 
-              %td.col-md-2{style: "padding:20px 8px 20px 8px;"}
-                = link_to 'Complete your proposal', 'javascript: void(0)', "type"=>"button", "data-trigger"=>"focus", "data-toggle"=>"popover", "title"=>"Your todo list", "data-content"=>"#{render partial: 'tooltip', locals: { event: event} }"
+              - progress_percentage = event.calculate_progress
+              - if progress_percentage.to_i < 100
+                %td.col-md-2{style: "padding:20px 8px 20px 8px;"}
+                  = link_to 'Complete your proposal', 'javascript: void(0)', "type"=>"button", "data-trigger"=>"focus", "data-toggle"=>"popover", "title"=>"Your todo list", "data-content"=>"#{render partial: 'tooltip', locals: { event: event} }"
 
-                - progress_percentage = event.calculate_progress
-                .progress
-                  %div{class: "progress-bar #{event_progress_color(progress_percentage)}", style: "width:#{progress_percentage}%;"}
-                    = event.progress_status.reject{ |_key, value| value || value.nil? }.length
+                  .progress
+                    %div{class: "progress-bar #{event_progress_color(progress_percentage)}", style: "width:#{progress_percentage}%;"}
+                      = event.progress_status.reject{ |_key, value| value || value.nil? }.length
                     left
 
               %td.col-md-3{style: "padding:20px 0px 20px 0px;"}

--- a/db/migrate/20180522011758_add_speaker_proposal_requirements_to_programs.rb
+++ b/db/migrate/20180522011758_add_speaker_proposal_requirements_to_programs.rb
@@ -1,0 +1,10 @@
+class AddSpeakerProposalRequirementsToPrograms < ActiveRecord::Migration
+  def change
+    add_column :programs, :speaker_proposals_req_speaker_event_reg, :boolean, default: true
+    add_column :programs, :speaker_proposals_req_bio, :boolean, default: true
+    add_column :programs, :speaker_proposals_req_subtitle, :boolean, default: true
+    add_column :programs, :speaker_proposals_req_commercial, :boolean, default: true
+    add_column :programs, :speaker_proposals_req_track, :boolean, default: true
+    add_column :programs, :speaker_proposals_req_difficulty_level, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170614025428) do
+ActiveRecord::Schema.define(version: 20180522011758) do
 
   create_table "ahoy_events", force: :cascade do |t|
     t.uuid     "visit_id",   limit: 16
@@ -290,17 +290,23 @@ ActiveRecord::Schema.define(version: 20170614025428) do
 
   create_table "programs", force: :cascade do |t|
     t.integer  "conference_id"
-    t.integer  "rating",               default: 0
-    t.boolean  "schedule_public",      default: false
-    t.boolean  "schedule_fluid",       default: false
+    t.integer  "rating",                                  default: 0
+    t.boolean  "schedule_public",                         default: false
+    t.boolean  "schedule_fluid",                          default: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "languages"
-    t.boolean  "blind_voting",         default: false
+    t.boolean  "blind_voting",                            default: false
     t.datetime "voting_start_date"
     t.datetime "voting_end_date"
     t.integer  "selected_schedule_id"
-    t.integer  "schedule_interval",    default: 15,    null: false
+    t.integer  "schedule_interval",                       default: 15,    null: false
+    t.boolean  "speaker_proposals_req_speaker_event_reg", default: true
+    t.boolean  "speaker_proposals_req_bio",               default: true
+    t.boolean  "speaker_proposals_req_subtitle",          default: true
+    t.boolean  "speaker_proposals_req_commercial",        default: true
+    t.boolean  "speaker_proposals_req_track",             default: true
+    t.boolean  "speaker_proposals_req_difficulty_level",  default: true
   end
 
   add_index "programs", ["selected_schedule_id"], name: "index_programs_on_selected_schedule_id"

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -158,6 +158,19 @@ describe Program do
     end
   end
 
+  describe 'supports configuring speaker proposal requirements' do
+    describe 'defaults to requiring everything in speaker proposals' do
+      it 'when the program is first set up' do
+        expect(program.speaker_proposals_req_speaker_event_reg).to eq true
+        expect(program.speaker_proposals_req_bio).to eq true
+        expect(program.speaker_proposals_req_subtitle).to eq true
+        expect(program.speaker_proposals_req_commercial).to eq true
+        expect(program.speaker_proposals_req_track).to eq true
+        expect(program.speaker_proposals_req_difficulty_level).to eq true
+      end
+    end
+  end
+
   describe 'excecutes before_create functions' do
     it 'and creates events_types' do
       program.destroy!


### PR DESCRIPTION
#13 describes an issue: SeaGL does not want to ask speakers to complete all 6 actions currently associated with proposals in OSEM. The OP mentions in an ideal world CFP setup would allow conference organisers to toggle what actions speakers are requested to perform. Now, nothing is ideal, but we can strive for it :).

1. Add ability to toggle each requirement to CFP setup. The following changes were made:

    - app/assets/stylesheets/osem.css.scss: an extra spacing class for CFP display
    - app/controllers/admin/cfps_controller.rb: processing the new 6 options. Not *terrible* but by far the hackiest part of the PR. Rails and Formtastic are just not behaving as I was expecting but I'm running out of time to debug.
    - app/models/cfp.rb: Each speaker requirement/reminder is added as an attribute to the event program, but we want the CFP setup to update those attributes. So, we allow CFPs to take on nested attributes for updating the program.
    - app/views/admin/cfps/_form.html.haml: add the 6 toggles to the CFP edit form
    - app/views/admin/cfps/show.html.haml: show the 6 toggles on the CFP view page
    - db/migrate/20180522011758_add_speaker_proposal_requirements_to_programs.rb: add the 6 toggles to the Program model
    - db/schema.rb: update to include results of migration ^
    - spec/models/program_spec.rb: rudimentary test to set expectation that the 6 toggles should be on by default. I haven't figured enough of OSEM's setup yet to write the rest of the tests I'd want :(

    ![untitled](https://user-images.githubusercontent.com/1190172/40461615-1a358470-5f04-11e8-9231-41c87b8f9fd5.png)

2. Only ask the speakers to do what the OSEM event admins want (aka the whole point of this feature):
    1. All 6 proposal requirements are turned on (same as now):
        ![untitled](https://user-images.githubusercontent.com/1190172/40462010-ee4814d4-5f05-11e8-8872-65dfa37f4b93.png)
    2. Only 1 proposal requirement is on. Et voila, it works!
        ![untitled](https://user-images.githubusercontent.com/1190172/40462121-818d1168-5f06-11e8-9518-5deed6d4dc3d.png)
    3. No proposal requirements are on - I decided to hide the entire progress bar and speaker todo list since it's all empty in this case.
        ![untitled](https://user-images.githubusercontent.com/1190172/40462270-28c2c39c-5f07-11e8-9f13-e2c01787954b.png)

    Files affected:

    - app/models/event.rb: calculate the little speakers todo list progress bar more selectively based on what toggles are on. So it says "2 left" when 2 are on rather than "6 left".
    - app/views/proposals/_tooltip.html.haml: hide speaker todo tasks if the event admins have so decided
    - app/views/proposals/index.html.haml: hide the entire speaker todo list and progress bar if the event admins have turned off all 6 toggles