### PR TITLE
After registration, show the home page instead of the account edit screen.

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -18,7 +18,7 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def after_sign_up_path_for(resource)
-    edit_user_registration_path(resource)
+    root_path
   end
 
   def configure_permitted_parameters

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,7 +2,7 @@
   .row
     .col-md-12
       .page-header
-        %h1 Edit your Account or Click on the word "SeaGL" in the top left, to return to the paper submission page
+        %h1 Edit your Account
   .row
     .col-md-12
       = semantic_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|


### PR DESCRIPTION
Rather than instruct people to click back to the home page, we can just show it in the first place.